### PR TITLE
BUGFIX: Remove unnecessary quotes

### DIFF
--- a/Resources/Private/Templates/NodeTypes/Code.html
+++ b/Resources/Private/Templates/NodeTypes/Code.html
@@ -1,4 +1,4 @@
 <div {attributes -> f:format.raw()}>
-    <pre {preAttributes -> f:format.raw()}><code {codeAttributes -> f:format.raw()}">{node.properties.source}</code></pre>
+    <pre {preAttributes -> f:format.raw()}><code {codeAttributes -> f:format.raw()}>{node.properties.source}</code></pre>
     <f:if condition="{node.properties.description}"><p class="code-description">{node.properties.description}</p></f:if>
 </div>


### PR DESCRIPTION
These quotes broke AMP and other validators
but doen't show as an error in normal browsers.